### PR TITLE
Fix #3: Support ignoring arguments on focus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,50 @@
 marathon
 ========
 
-**marathon** is a minimal shell-based launcher for Linux that tries to be smart about running or focusing apps. When calling `marathon foo`,
+**marathon** is a minimal shell-based launcher for Linux/X that tries to be
+smart about running or focusing apps. When calling `marathon application`,
 
-* If `foo` is not running, marathon will **run** it.
-* Else marathon will just **focus** `foo`
+* If `application` is not running, marathon will **run** it.
+* Else marathon will just **focus** `application`
 
-That way, after binding your favorite apps to a few easily-accessible keyboard shortcuts, you can access them with a single keypress and **forget about alt-tabbing or clicking on stuff in your dock / selector**.
+That way, after binding your favorite apps to a few easily-accessible OS
+global keyboard shortcuts, you can access them with a single keypress and
+**forget about alt-tabbing or clicking on stuff in your dock / window list**.
 
-By default, marathon will have no effect on already-focused windows, but a `--toggle` flag is supported to emulate the Quake-like behavior of instead *minimizing* the focused window.
+Flags:
+
+* `--toggle` will emulate the Quake terminal-like behavior of *minimizing*
+  already-focused windows. (By default, marathon leave them untouched.)
+
+* `--ignore-args-on-focus` will *ignore command arguments when focusing*
+   (e.g. `--incognito` in `marathon google-chrome --incognito`) while still
+   passing them on initial run.
+   - This is useful for applications who use a runner or spawn other processes,
+     making ineffective post-exec searching for the fully-qualified command.
+   - This is not what you want if the process you want to focus needs arguments
+     to be uniquely identified (e.g. `gvim -S work`).
 
 Installation
 ------------
 
-- **Mac OSX is not supported, sorry**. But rejoice, you'll be well served with Automator or Alfred, see [this guide](http://superuser.com/questions/245711/starting-application-with-custom-keyboard-shortcut) for example.  
+- **Mac OSX is not supported**, sorry (due to depending on X11 utilities).
+  But rejoice, you'll be well served with Automator or Alfred, see for example
+  [this guide](http://superuser.com/questions/245711/starting-application-with-custom-keyboard-shortcut)
 
 - **Linux**:
     1. **Install `wmctrl` and `xdotool`** from your package manager.
     2. Drop `marathon` somewhere in your `$PATH`.
-    3. Bind `marathon command` to some keyboard shortcut:
-        * GNOME → Settings → *Keyboard* section → *Shortcut* tab → *Custom Shortcuts*. Mine look like:  
-        ![GNOME Keyboard Settings screenshot](gnome-keyboard-settings-screenshot.png)
+    3. Bind `marathon command` (optionally adding flags) to a keyboard shortcut:
+        * GNOME → Settings → *Keyboard* section → *Shortcut* tab → *Custom Shortcuts*.
+          Mine look like:  
+          ![GNOME Keyboard Settings screenshot](gnome-keyboard-settings-screenshot.png)
         * LXDE → your `lxde-rc.xml`
 
 Support, license, contact
 -------------------------
 
-[Bug Reports](https://github.com/ronjouch/marathon/issues) and [Pull Requests](https://github.com/ronjouch/marathon/pulls) are welcome via GitHub.
+[Bug Reports](https://github.com/ronjouch/marathon/issues) and
+[Pull Requests](https://github.com/ronjouch/marathon/pulls) are welcome.
 
-Licensed under the MIT license, 2012-2015, [ronan@jouchet.fr](mailto:ronan@jouchet.fr) / [@ronjouch](https://twitter.com/ronjouch)
+Licensed under the MIT license, 2012-2016,
+[ronan@jouchet.fr](mailto:ronan@jouchet.fr) / [@ronjouch](https://twitter.com/ronjouch)

--- a/marathon
+++ b/marathon
@@ -1,38 +1,56 @@
 #! /bin/sh
-# See documentation and license in README.md
+# See documentation, requirements, license in README.md
 
-if [ "$1" = "--toggle" ]; then
-	shift
-	toggle=1
+toggle=0
+ignoreArgsOnFocus=0
+cmdForFocus=""
+
+# Nit: [[ "$1" == --* ]] would work here, but would be bash (globbing) only.
+while [ "$1" = "--toggle" ] || [ "$1" = "--ignore-args-on-focus" ]; do
+  if [ "$1" = "--toggle" ]; then
+    shift
+    toggle=1
+  elif [ "$1" = "--ignore-args-on-focus" ]; then
+    shift
+    ignoreArgsOnFocus=1
+  fi
+done
+
+# Done processing/shifting all arguments
+cmd="$*"
+if [ "$ignoreArgsOnFocus" = "1" ]; then
+  cmdForFocus="$1"
 else
-	toggle=0
+  cmdForFocus="$*"
 fi
 
-command="$*"
-# zenity --info --text "$command"; # useful for debug
-
-runningInstancesOfExec=$(ps -a -x -o command | grep -v grep | grep -v defunct | grep -v marathon | grep -c $command);
+runningInstancesOfExec=$(ps -a -x -o command |
+                         grep -v grep |
+                         grep -v defunct |
+                         grep -v marathon |
+                         grep -c "$cmdForFocus");
+# zenity --info --text "$runningInstancesOfExec"; # useful for debug
 
 if [ "$runningInstancesOfExec" -gt "0" ]; then
-	if [ "$toggle" = "1" ]; then
-		# Determine active windowID, from https://github.com/dmikalova/brocket
-		# and http://superuser.com/questions/382616/detecting-currently-active-window
-		currentWindow="$(printf '0x%08x\n' $(xprop -root |
-						 grep "_NET_ACTIVE_WINDOW(WINDOW)" |
-						 grep -E -o 0x[0-9a-f]+))"
+  if [ "$toggle" = "1" ]; then
+    # Determine active windowID, from https://github.com/dmikalova/brocket and
+    # http://superuser.com/questions/382616/detecting-currently-active-window
+    currentWindow="$(printf '0x%08x\n' $(xprop -root |
+                     grep "_NET_ACTIVE_WINDOW(WINDOW)" |
+                     grep -E -o '0x[0-9a-f]+'))"
 
-		currentWindowIsCommand="$(wmctrl -lx |
-								  grep $currentWindow |
-			 					  grep -ci "^0x[0-9a-f]*\s*[0-9]\s*[^ ]*$command")"
-		if [ "$currentWindowIsCommand" -gt 0 ]; then
-			exec xdotool windowminimize $currentWindow
-		else
-			exec wmctrl -x -a $command;
-		fi
-	else
-		exec wmctrl -x -a $command;
-	fi
+    currentWindowIsCommand="$(wmctrl -lx |
+                              grep $currentWindow |
+                              grep -ci "^0x[0-9a-f]*\s*[0-9]\s*[^ ]*$cmdForFocus")"
+    if [ "$currentWindowIsCommand" -gt 0 ]; then
+      exec xdotool windowminimize $currentWindow
+    else
+      # Try to find our command in both places (useful for some programs)
+      wmctrl -x -a $cmdForFocus || wmctrl -a $cmdForFocus;
+    fi
+  else
+    wmctrl -x -a $cmdForFocus || wmctrl -a $cmdForFocus;
+  fi
 else
-	exec $command;
+  exec $cmd;
 fi
-


### PR DESCRIPTION
It's optional (behind the `--ignore-args-on-focus` flag) and doesn't change the default behavior.

See the updated documentation for the rationale.

Also, re-indent tabs to spaces and stay below 80 columns.
